### PR TITLE
refactor: optimize parallel build and fix architectural issues

### DIFF
--- a/src/core/builder/common.rs
+++ b/src/core/builder/common.rs
@@ -153,6 +153,49 @@ pub fn has_glob_magic(value: &str) -> bool {
     value.chars().any(|c| matches!(c, '*' | '?' | '['))
 }
 
+pub fn parallel_build<F>(total_tasks: usize, task_fn: F) -> Result<(), String>
+where
+    F: Fn(usize) -> Result<(), String> + Sync + Send,
+{
+    let num_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    let counter = std::sync::atomic::AtomicUsize::new(0);
+    let err_msg = std::sync::Mutex::new(None);
+
+    std::thread::scope(|s| {
+        for _ in 0..num_threads {
+            s.spawn(|| {
+                loop {
+                    if err_msg.lock().unwrap().is_some() {
+                        break;
+                    }
+
+                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if i >= total_tasks {
+                        break;
+                    }
+
+                    if let Err(e) = task_fn(i) {
+                        let mut err = err_msg.lock().unwrap();
+                        if err.is_none() {
+                            *err = Some(e);
+                        }
+                        break;
+                    }
+                }
+            });
+        }
+    });
+
+    if let Some(err) = err_msg.into_inner().unwrap() {
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 pub fn normalize_source_path(path: &Path) -> String {
     if !path.is_absolute() {
         return path.to_string_lossy().to_string();

--- a/src/core/builder/gas.rs
+++ b/src/core/builder/gas.rs
@@ -112,44 +112,9 @@ fn build_objects(
         .map(|s| common::object_path(obj_dir, s, obj_ext))
         .collect();
 
-    let num_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-
-    let counter = std::sync::atomic::AtomicUsize::new(0);
-    let err_msg = std::sync::Mutex::new(None);
-
-    std::thread::scope(|s| {
-        for _ in 0..num_threads {
-            s.spawn(|| {
-                loop {
-                    if err_msg.lock().unwrap().is_some() {
-                        break;
-                    }
-
-                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    if i >= sources.len() {
-                        break;
-                    }
-
-                    let source = &sources[i];
-                    let obj_path = &objects[i];
-
-                    if let Err(e) = build_object(assembler, source, obj_path, ctx) {
-                        let mut err = err_msg.lock().unwrap();
-                        if err.is_none() {
-                            *err = Some(e);
-                        }
-                        break;
-                    }
-                }
-            });
-        }
-    });
-
-    if let Some(err) = err_msg.into_inner().unwrap() {
-        return Err(err);
-    }
+    common::parallel_build(sources.len(), |i| {
+        build_object(assembler, &sources[i], &objects[i], ctx)
+    })?;
 
     Ok(objects)
 }

--- a/src/core/builder/msvc.rs
+++ b/src/core/builder/msvc.rs
@@ -185,6 +185,8 @@ fn default_flags(profile: &str) -> &'static [&'static str] {
     }
 }
 
+static OUTPUT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn build_objects(
     compiler: &str,
     sources: &[String],
@@ -197,44 +199,9 @@ fn build_objects(
         .map(|s| common::object_path(obj_dir, s, obj_ext))
         .collect();
 
-    let num_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-
-    let counter = std::sync::atomic::AtomicUsize::new(0);
-    let err_msg = std::sync::Mutex::new(None);
-
-    std::thread::scope(|s| {
-        for _ in 0..num_threads {
-            s.spawn(|| {
-                loop {
-                    if err_msg.lock().unwrap().is_some() {
-                        break;
-                    }
-
-                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    if i >= sources.len() {
-                        break;
-                    }
-
-                    let source = &sources[i];
-                    let obj_path = &objects[i];
-
-                    if let Err(e) = build_object(compiler, source, obj_path, ctx) {
-                        let mut err = err_msg.lock().unwrap();
-                        if err.is_none() {
-                            *err = Some(e);
-                        }
-                        break;
-                    }
-                }
-            });
-        }
-    });
-
-    if let Some(err) = err_msg.into_inner().unwrap() {
-        return Err(err);
-    }
+    common::parallel_build(sources.len(), |i| {
+        build_object(compiler, &sources[i], &objects[i], ctx)
+    })?;
 
     Ok(objects)
 }
@@ -314,6 +281,8 @@ fn build_object(
             clean_stdout.push('\n');
         }
     }
+
+    let _lock = OUTPUT_MUTEX.lock().unwrap();
 
     if !output.status.success() {
         eprint!("{}", clean_stdout);

--- a/src/core/builder/nasm.rs
+++ b/src/core/builder/nasm.rs
@@ -112,45 +112,11 @@ fn build_objects(
         .map(|s| common::object_path(obj_dir, s, obj_ext))
         .collect();
 
-    let num_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-
-    let counter = std::sync::atomic::AtomicUsize::new(0);
-    let err_msg = std::sync::Mutex::new(None);
     let format = nasm_format(ctx.platform);
 
-    std::thread::scope(|s| {
-        for _ in 0..num_threads {
-            s.spawn(|| {
-                loop {
-                    if err_msg.lock().unwrap().is_some() {
-                        break;
-                    }
-
-                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    if i >= sources.len() {
-                        break;
-                    }
-
-                    let source = &sources[i];
-                    let obj_path = &objects[i];
-
-                    if let Err(e) = build_object(assembler, source, obj_path, format, ctx) {
-                        let mut err = err_msg.lock().unwrap();
-                        if err.is_none() {
-                            *err = Some(e);
-                        }
-                        break;
-                    }
-                }
-            });
-        }
-    });
-
-    if let Some(err) = err_msg.into_inner().unwrap() {
-        return Err(err);
-    }
+    common::parallel_build(sources.len(), |i| {
+        build_object(assembler, &sources[i], &objects[i], format, ctx)
+    })?;
 
     Ok(objects)
 }

--- a/src/core/builder/unix_cc.rs
+++ b/src/core/builder/unix_cc.rs
@@ -137,44 +137,9 @@ fn build_objects(
         .map(|s| common::object_path(obj_dir, s, obj_ext))
         .collect();
 
-    let num_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-
-    let counter = std::sync::atomic::AtomicUsize::new(0);
-    let err_msg = std::sync::Mutex::new(None);
-
-    std::thread::scope(|s| {
-        for _ in 0..num_threads {
-            s.spawn(|| {
-                loop {
-                    if err_msg.lock().unwrap().is_some() {
-                        break;
-                    }
-
-                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    if i >= sources.len() {
-                        break;
-                    }
-
-                    let source = &sources[i];
-                    let obj_path = &objects[i];
-
-                    if let Err(e) = build_object(compiler, source, obj_path, ctx) {
-                        let mut err = err_msg.lock().unwrap();
-                        if err.is_none() {
-                            *err = Some(e);
-                        }
-                        break;
-                    }
-                }
-            });
-        }
-    });
-
-    if let Some(err) = err_msg.into_inner().unwrap() {
-        return Err(err);
-    }
+    common::parallel_build(sources.len(), |i| {
+        build_object(compiler, &sources[i], &objects[i], ctx)
+    })?;
 
     Ok(objects)
 }


### PR DESCRIPTION
This PR refactors the recently merged parallel build implementation. It moves the core logic to common.rs to eliminate code duplication, fixes potential scope issues, optimizes atomic ordering, and synchronizes console output for MSVC.