### PR TITLE
build(nix): configure flake for dcr project

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: 'https://dalink.to/dexoron'

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,135 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1780218205,
+        "narHash": "sha256-c4MSlBQw5MIDRkad9UNUUnBaOHAHnhuCXrDt90FDVrg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "96e0fc9f1a9b37f6477fa11c3fd48575354773ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780179631,
+        "narHash": "sha256-61A3gj4V1DyPP6lVHTdui4+dvG66pkMZSMd1Kke3Rz8=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "cce33f2f1565958787bb763ae751a6a5f56b95e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -96,10 +96,7 @@
 
         packages = [
           rustToolchain
-
           pkgs.rust-analyzer
-          pkgs.just
-          pkgs.podman-compose
 
           treefmtEval.config.build.wrapper
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,112 @@
+{
+  description = "DCR — Cargo-like utility for managing C/C++ projects";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    treefmt-nix,
+    fenix,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      packageName = "dcr";
+
+      rustToolchain = fenix.packages.${system}.stable.toolchain;
+
+      rustPlatform = pkgs.makeRustPlatform {
+        cargo = rustToolchain;
+        rustc = rustToolchain;
+      };
+
+      treefmtEval = treefmt-nix.lib.evalModule pkgs {
+        projectRootFile = "flake.nix";
+
+        programs.alejandra.enable = true;
+        programs.rustfmt.enable = true;
+        programs.taplo.enable = true;
+      };
+
+      app = rustPlatform.buildRustPackage {
+        pname = packageName;
+        version = "0.6.9";
+
+        src = ./.;
+
+        cargoLock.lockFile = ./Cargo.lock;
+
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.cmake
+          pkgs.perl
+        ];
+
+        buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+          pkgs.darwin.apple_sdk.frameworks.Security
+          pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+
+        # Tests require external services; run separately.
+        doCheck = false;
+      };
+    in {
+      packages = {
+        default = app;
+        dcr = app;
+      };
+
+      apps = let
+        defaultApp =
+          (flake-utils.lib.mkApp {
+            drv = app;
+          })
+          // {
+            meta.description = "Run ${packageName}";
+          };
+      in {
+        default = defaultApp;
+        dcr = defaultApp;
+      };
+
+      checks = {
+        dcr = app;
+        formatting = treefmtEval.config.build.check self;
+      };
+
+      formatter = treefmtEval.config.build.wrapper;
+
+      devShells.default = pkgs.mkShell {
+        inputsFrom = [app];
+
+        packages = [
+          rustToolchain
+
+          pkgs.rust-analyzer
+          pkgs.just
+          pkgs.podman-compose
+
+          treefmtEval.config.build.wrapper
+        ];
+
+        shellHook = ''
+          export RUST_SRC_PATH="${rustToolchain}/lib/rustlib/src/rust/library"
+        '';
+      };
+    });
+}

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ select_channel() {
     echo "Choose channel:"
     echo "  1) Latest stable release (default)"
     echo "  2) Latest dev (pre-release)"
-    read -r -p "Enter 1 or 2 [1]: " choice
+    read -r -p "Enter 1 or 2 [1]: " choice < /dev/tty
 
     case "${choice:-1}" in
         1) CHANNEL="stable" ;;
@@ -74,7 +74,7 @@ select_install_mode() {
     echo "Choose installation mode:"
     echo "  1) Download prebuilt binary from GitHub Release (recommended)"
     echo "  2) Build from git"
-    read -r -p "Enter 1 or 2 [1]: " choice
+    read -r -p "Enter 1 or 2 [1]: " choice < /dev/tty
 
     case "${choice:-1}" in
         1) INSTALL_MODE="release" ;;


### PR DESCRIPTION
## Add Nix flake support

  Adds `flake.nix` and `flake.lock` to build and install `dcr` via Nix flakes.

  Builds against Rust stable toolchain

  ## Installation

  Add to `inputs`:

  ```nix
  inputs.dcr.url = "github:dexoron/dcr";
```
  Then via specialArgs add to environment.systemPackages:

```nix
  environment.systemPackages = [
    inputs.dcr.packages.${pkgs.stdenv.hostPlatform.system}.dcr
  ];
```

  Or run without installing:
```bash
nix run github:dexoron/dcr
```
  What's included

  - packages.default / packages.dcr — the dcr binary
  - apps.default / apps.dcr — runnable via nix run
  - devShells.default — development environment with Rust stable, rust-analyzer, just, podman-compose
  - formatter — alejandra + rustfmt + taplo via nix fmt
  - checks.formatting — format check via nix flake check