### PR TITLE
docs: fix README badge rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-<div align="center">
+<h1 align="center">DCR — Dexoron Cargo Realization</h1>
 
-# DCR — Dexoron Cargo Realization
+<p align="center"><strong>A Cargo-style build tool for C/C++ projects</strong></p>
 
-**A Cargo-style build tool for C/C++ projects**
+<p align="center">
+  <a href="https://github.com/dexoron/dcr/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/dexoron/dcr/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/dexoron/dcr/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/dexoron/dcr"></a>
+  <a href="https://github.com/dexoron/dcr/releases"><img alt="Platform" src="https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-lightgrey"></a>
+  <br>
+  <a href="https://aur.archlinux.org/packages/dcr"><img alt="AUR" src="https://img.shields.io/aur/version/dcr"></a>
+  <a href="https://crates.io/crates/dcr"><img alt="Crates.io" src="https://img.shields.io/crates/v/dcr"></a>
+  <a href="https://github.com/dexoron/homebrew-dexoron"><img alt="Homebrew" src="https://img.shields.io/badge/homebrew-dexoron%2Fdexoron-orange"></a>
+  <br>
+  <a href="https://github.com/dexoron/dcr/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/dexoron/dcr?style=flat"></a>
+  <a href="LICENSE"><img alt="License: GPL-3.0" src="https://img.shields.io/badge/License-GPL--3.0-blue.svg"></a>
+</p>
 
-[![CI](https://github.com/dexoron/dcr/actions/workflows/ci.yml/badge.svg)](https://github.com/dexoron/dcr/actions/workflows/ci.yml)
-[![GitHub Release](https://img.shields.io/github/v/release/dexoron/dcr)](https://github.com/dexoron/dcr/releases/latest)
-[![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-lightgrey)](https://github.com/dexoron/dcr/releases)
-<br/>
-[![AUR](https://img.shields.io/aur/version/dcr)](https://aur.archlinux.org/packages/dcr)
-[![Crates.io](https://img.shields.io/crates/v/dcr)](https://crates.io/crates/dcr)
-[![Homebrew](https://img.shields.io/badge/homebrew-dexoron%2Fdexoron-orange)](https://github.com/dexoron/homebrew-dexoron)
-<!-- Snap badge removed — classic confinement was denied for this project. -->
-<br/>
-[![GitHub Stars](https://img.shields.io/github/stars/dexoron/dcr?style=flat)](https://github.com/dexoron/dcr/stargazers)
-[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
-
-</div>
+<!-- Snap badge removed: classic confinement was denied for this project. -->
 
 ---
 


### PR DESCRIPTION
## Issue
The README badge section does not fully render on GitHub. The `GitHub Stars` and `License: GPL-3.0` badges appear as raw Markdown/text links instead of badge images, while the earlier badges in the same section render correctly.

## Root cause
The README header mixed Markdown badge syntax inside an HTML-centered block and placed an HTML comment in the middle of the badge group. GitHub Markdown converted the badges before the comment into images, but the badges after it were no longer parsed as Markdown image links and were emitted as plain linked text.

## Fix
This changes the header badge group to use explicit HTML `<a><img></a>` badge links throughout, so GitHub does not need to parse Markdown image syntax inside the HTML block. It also keeps the heading and badge group centered and moves the Snap note outside the badge block.

## Verification
- Rendered the updated README with GitHub Markdown raw API.
- Confirmed the `GitHub Stars` and `License: GPL-3.0` entries are emitted as `<img>` elements with the expected `data-canonical-src` values.
- Ran `git diff --check`.